### PR TITLE
fix: remove wrong picture-in feature section (Closes #64)

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
       <section class="features">
         <div class="container">
           <h2>Warum LiveCalls?</h2>
-          <img alt="Laptop mit Kopfhörern" src="./images/logo/livecalls-logo.png" />
           <div class="feature-grid">
             <article class="feature-card">
               <h3>Zuverlässige Qualität</h3>


### PR DESCRIPTION
Closes Issue number #64:
Removed obviously unintended image from the feature section.
<img width="741" height="447" alt="image" src="https://github.com/user-attachments/assets/afcd7eda-e7b9-4581-b086-e7560d0ef122" />
