### PR TITLE
fix: center last feature card in tablet layout

### DIFF
--- a/css/features.css
+++ b/css/features.css
@@ -45,7 +45,7 @@
   line-height: 1.6;
 }
 
-@media (min-width: 600px) and (max-width: 900px) {
+@media (600px <= width <= 900px) {
   .feature-grid {
     grid-template-columns: repeat(2, minmax(280px, 1fr));
   }

--- a/css/features.css
+++ b/css/features.css
@@ -44,3 +44,15 @@
   color: var(--features-text);
   line-height: 1.6;
 }
+
+@media (min-width: 600px) and (max-width: 900px) {
+  .feature-grid {
+    grid-template-columns: repeat(2, minmax(280px, 1fr));
+  }
+
+  .feature-card:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+    width: calc((100% - var(--spacing-lg)) / 2);
+    justify-self: center;
+  }
+}


### PR DESCRIPTION
When the number of feature cards is uneven, span the final card across both columns and center it while keeping the width of a single column.